### PR TITLE
Fix functions that use $post after the $wp_query change.

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -74,6 +74,9 @@ function maybe_render_template( string $default_template ) : string {
 	$wp_query->post_count++;
 	array_unshift( $wp_query->posts, $wp_query->post );
 
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- required to fix get_post_type() after the $wp_query change.
+	$GLOBALS['post'] = $wp_query->posts[0];
+
 	return \locate_template(
 		[
 			"pragcat-{$taxonomy}.php",

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
  * Description: Customise the WordPress term archive template with the block editor.
  * Author: Pragmatic Web Limited
  * Author URI: https://pragmatic.agency
- * Version: 0.6.0
+ * Version: 0.7.0
  * License: GPL-3.0-only
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain: customisable-archive-templates


### PR DESCRIPTION
## Description
It was pointing to the first post of the taxonomy results, instead of the
hub post that is inserted at the top of the stack.

## Motivation and context
Fix WP template loop functions when used above the main loop start (e.g. header.php).

## How has this been tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
